### PR TITLE
Update ttf-parser so RustyBuzz can be updated downstream

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["rendering", "font"]
 exclude = ["fonts/*"]
 
 [dependencies]
-ttf-parser = "0.24"
+ttf-parser = "0.25"
 
 [dev-dependencies]
 iai = { git = "https://github.com/reknih/iai" }


### PR DESCRIPTION
I set out to make sure bumping the RustyBuzz dependency in Typst didn't break anything. It turns out hard to do without ending up with multiple versions of dependencies and conflicting types, but I think I have it all sorted now. This bump will need to be in a release to properly update the lock file, but I already have a working PoC using Git dependencies.
